### PR TITLE
mediaextractor: allow nanosleep syscall in seccomp policy

### DIFF
--- a/services/mediaextractor/minijail/seccomp_policy/mediaextractor-seccomp-x86.policy
+++ b/services/mediaextractor/minijail/seccomp_policy/mediaextractor-seccomp-x86.policy
@@ -35,6 +35,7 @@ geteuid32: 1
 getgid32: 1
 getegid32: 1
 getgroups32: 1
+nanosleep: 1
 
 # for attaching to debuggerd on process crash
 socketcall: 1


### PR DESCRIPTION
See https://android.googlesource.com/platform/frameworks/av/+/85e6bdd2b2bfd146a1d07c6edb52be5961ed18ba
for the corresponding upstream change.